### PR TITLE
Use withTiming to smooth animation

### DIFF
--- a/step1/App.js
+++ b/step1/App.js
@@ -6,6 +6,8 @@ import * as Speech from "expo-speech";
 import Reanimated, {
   useAnimatedStyle,
   useSharedValue,
+  withTiming,
+  Easing,
 } from "react-native-reanimated";
 import {
   SafeAreaProvider,

--- a/step1/README.md
+++ b/step1/README.md
@@ -91,6 +91,8 @@ import * as Speech from "expo-speech";
 import Reanimated, {
   useAnimatedStyle,
   useSharedValue,
+  withTiming,
+  Easing,
 } from "react-native-reanimated";
 import {
   SafeAreaProvider,

--- a/step2/App.js
+++ b/step2/App.js
@@ -6,6 +6,8 @@ import * as Speech from "expo-speech";
 import Reanimated, {
   useAnimatedStyle,
   useSharedValue,
+  withTiming,
+  Easing,
 } from "react-native-reanimated";
 import {
   SafeAreaProvider,
@@ -24,6 +26,7 @@ export default function App() {
 const BALL_WIDTH = 20;
 const TARGET_WIDTH = BALL_WIDTH * 2;
 const TARGET_BORDER_WIDTH = 2;
+const UPDATE_INTERVAL = 16 // 16ms is equivalent to 60fps
 
 const Game = () => {
   const { width, height } = useSafeAreaFrame();
@@ -48,19 +51,18 @@ const Game = () => {
   // Create the ball styles based on the current ballAnimation value
   const ballPosition = useAnimatedStyle(() => ({
     transform: [
-      { translateX: ballAnimation.value.x },
-      { translateY: ballAnimation.value.y },
+      { translateX: withTiming(ballAnimation.value.x, { duration: UPDATE_INTERVAL, easing: Easing.linear }) },
+      { translateY: withTiming(ballAnimation.value.y, { duration: UPDATE_INTERVAL, easing: Easing.linear }) },
     ],
   }));
 
   // START: STEP 2 ADDITION
   // Setup the device motion sensor listener
   React.useEffect(() => {
-    // Set the update interval to 16ms (60fps)
-    DeviceMotion.setUpdateInterval(16);
+    DeviceMotion.setUpdateInterval(UPDATE_INTERVAL);
 
     const subscription = DeviceMotion.addListener((deviceMotionMeasurment) => {
-      // Don't do anthing if the expected `rotation` data is missing
+      // Don't do anything if the expected `rotation` data is missing
       if (!deviceMotionMeasurment.rotation) {
         return;
       }

--- a/step2/README.md
+++ b/step2/README.md
@@ -81,17 +81,7 @@ React.useEffect(() => {
 
 ### 4. Make it smoother
 
-This updates the ball position every time an event comes in, but it doesn't smooth the transition between events. React Native Reanimated provides a selection of `with*` functions to provide different types of animation tweening and smoothing: we know the intended duration (16ms), so `withTiming` is a good fit. Let's add `withTiming` and `Easing` imports, using "linear" easing for steady constant transitions:
-
-```js
-import Reanimated, {
-  useAnimatedStyle,
-  useSharedValue,
-  withTiming,
-  Easing,
-} from "react-native-reanimated";
-```
-...and apply them in `useAnimatedStyle`:
+This updates the ball position every time an event comes in, but it doesn't smooth the transition between events. React Native Reanimated provides a selection of `with*` functions to provide different types of animation tweening and smoothing: we know the intended duration (16ms), so `withTiming` is a good fit, with "linear" easing for steady constant transitions:
 
 ```js
  // Create the ball styles based on the current ballAnimation value

--- a/step2/README.md
+++ b/step2/README.md
@@ -36,9 +36,10 @@ Depending on your device, you might see an unreasonably high or low number of lo
 Instead of letting the system guess, let's explicitly tell it. We can see in the Expo Sensors documentation that `DeviceMotion` has a `setUpdateInterval` method: let's use it, before we start the listener. 16ms is equivalent to 60 frames per second:
 
 ```js
+const UPDATE_INTERVAL = 16 // 16ms is equivalent to 60fps
+
 React.useEffect(() => {
-  // Set the update interval to 16ms (60fps)
-  DeviceMotion.setUpdateInterval(16);
+  DeviceMotion.setUpdateInterval(UPDATE_INTERVAL);
 
   const subscription = DeviceMotion.addListener((deviceMotionMeasurment) => {
 ```
@@ -53,11 +54,10 @@ From experimenting with the device and looking at the logs, we have probably not
 
 ```js
 React.useEffect(() => {
-  // Set the update interval to 16ms (60fps)
-  DeviceMotion.setUpdateInterval(16);
+  DeviceMotion.setUpdateInterval(UPDATE_INTERVAL);
 
   const subscription = DeviceMotion.addListener((deviceMotionMeasurment) => {
-    // Don't do anthing if the expected `rotation` data is missing
+    // Don't do anything if the expected `rotation` data is missing
     if (!deviceMotionMeasurment.rotation) {
       return;
     }
@@ -79,3 +79,26 @@ React.useEffect(() => {
 }, []); // <-- the empty array here means the function is only called once, after the first render
 ```
 
+### 4. Make it smoother
+
+This updates the ball position every time an event comes in, but it doesn't smooth the transition between events. React Native Reanimated provides a selection of `with*` functions to provide different types of animation tweening and smoothing: we know the intended duration (16ms), so `withTiming` is a good fit. Let's add `withTiming` and `Easing` imports, using "linear" easing for steady constant transitions:
+
+```js
+import Reanimated, {
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+  Easing,
+} from "react-native-reanimated";
+```
+...and apply them in `useAnimatedStyle`:
+
+```js
+ // Create the ball styles based on the current ballAnimation value
+  const ballPosition = useAnimatedStyle(() => ({
+    transform: [
+      { translateX: withTiming(ballAnimation.value.x, { duration: UPDATE_INTERVAL, easing: Easing.linear }) },
+      { translateY: withTiming(ballAnimation.value.y, { duration: UPDATE_INTERVAL, easing: Easing.linear }) },
+    ],
+  }));
+```

--- a/step3/App.js
+++ b/step3/App.js
@@ -6,6 +6,8 @@ import * as Speech from "expo-speech";
 import Reanimated, {
   useAnimatedStyle,
   useSharedValue,
+  withTiming,
+  Easing,
 } from "react-native-reanimated";
 import {
   SafeAreaProvider,
@@ -24,6 +26,7 @@ export default function App() {
 const BALL_WIDTH = 20;
 const TARGET_WIDTH = BALL_WIDTH * 2;
 const TARGET_BORDER_WIDTH = 2;
+const UPDATE_INTERVAL = 16 // 16ms is equivalent to 60fps
 
 const Game = () => {
   const { width, height } = useSafeAreaFrame();
@@ -48,8 +51,8 @@ const Game = () => {
   // Create the ball styles based on the current ballAnimation value
   const ballPosition = useAnimatedStyle(() => ({
     transform: [
-      { translateX: ballAnimation.value.x },
-      { translateY: ballAnimation.value.y },
+      { translateX: withTiming(ballAnimation.value.x, { duration: UPDATE_INTERVAL, easing: Easing.linear }) },
+      { translateY: withTiming(ballAnimation.value.y, { duration: UPDATE_INTERVAL, easing: Easing.linear }) },
     ],
   }));
 
@@ -68,11 +71,10 @@ const Game = () => {
 
   // Setup the device motion sensor listner
   React.useEffect(() => {
-    // Set the update interval to 16ms (60fps)
-    DeviceMotion.setUpdateInterval(16);
+    DeviceMotion.setUpdateInterval(UPDATE_INTERVAL);
 
     const subscription = DeviceMotion.addListener((deviceMotionMeasurment) => {
-      // Don't do anthing if the expected `rotation` data is missing
+      // Don't do anything if the expected `rotation` data is missing
       if (!deviceMotionMeasurment.rotation) {
         return;
       }

--- a/step4/App.js
+++ b/step4/App.js
@@ -6,6 +6,8 @@ import * as Speech from "expo-speech";
 import Reanimated, {
   useAnimatedStyle,
   useSharedValue,
+  withTiming,
+  Easing,
 } from "react-native-reanimated";
 import {
   SafeAreaProvider,
@@ -24,6 +26,7 @@ export default function App() {
 const BALL_WIDTH = 20;
 const TARGET_WIDTH = BALL_WIDTH * 2;
 const TARGET_BORDER_WIDTH = 2;
+const UPDATE_INTERVAL = 16 // 16ms is equivalent to 60fps
 
 const Game = () => {
   const { width, height } = useSafeAreaFrame();
@@ -48,8 +51,8 @@ const Game = () => {
   // Create the ball styles based on the current ballAnimation value
   const ballPosition = useAnimatedStyle(() => ({
     transform: [
-      { translateX: ballAnimation.value.x },
-      { translateY: ballAnimation.value.y },
+      { translateX: withTiming(ballAnimation.value.x, { duration: UPDATE_INTERVAL, easing: Easing.linear }) },
+      { translateY: withTiming(ballAnimation.value.y, { duration: UPDATE_INTERVAL, easing: Easing.linear }) },
     ],
   }));
 
@@ -66,11 +69,10 @@ const Game = () => {
 
   // Setup the device motion sensor listner
   React.useEffect(() => {
-    // Set the update interval to 16ms (60fps)
-    DeviceMotion.setUpdateInterval(16);
+    DeviceMotion.setUpdateInterval(UPDATE_INTERVAL);
 
     const subscription = DeviceMotion.addListener((deviceMotionMeasurment) => {
-      // Don't do anthing if the expected `rotation` data is missing
+      // Don't do anything if the expected `rotation` data is missing
       if (!deviceMotionMeasurment.rotation) {
         return;
       }

--- a/step4/README.md
+++ b/step4/README.md
@@ -32,9 +32,20 @@ When the ball is in the target, we want to move the target to a new random posit
 targetAnimation.value = getRandomTargetPosition();
 ```
 
+We can make this into a nice smooth animation by using `withTiming` again. The default animation easing is quite suitable for this, sliding in a natural-looking way:
+
+```js
+  const targetPosition = useAnimatedStyle(() => ({
+    transform: [
+      { translateX: withTiming(targetAnimation.value.x, { duration: 350 }) },
+      { translateY: withTiming(targetAnimation.value.y, { duration: 350 }) },
+    ],
+  }));
+```
+
 ### 2: Trigger haptic feedback
 
-A great benifit of React Native is that it makes access access to device functionality, such as audio, haptic feedback and the camera, very easy.
+A great benefit of React Native is that it makes access access to device functionality, such as audio, haptic feedback and the camera, very easy.
 
 To improve the user experience of our game, we can trigger haptic feedback when the ball collides with the target.
 

--- a/step5/App.js
+++ b/step5/App.js
@@ -6,6 +6,8 @@ import * as Speech from "expo-speech";
 import Reanimated, {
   useAnimatedStyle,
   useSharedValue,
+  withTiming,
+  Easing,
 } from "react-native-reanimated";
 import {
   SafeAreaProvider,
@@ -24,6 +26,7 @@ export default function App() {
 const BALL_WIDTH = 20;
 const TARGET_WIDTH = BALL_WIDTH * 2;
 const TARGET_BORDER_WIDTH = 2;
+const UPDATE_INTERVAL = 16 // 16ms is equivalent to 60fps
 
 const Game = () => {
   const { width, height } = useSafeAreaFrame();
@@ -53,8 +56,8 @@ const Game = () => {
   // Create the ball styles based on the current ballAnimation value
   const ballPosition = useAnimatedStyle(() => ({
     transform: [
-      { translateX: ballAnimation.value.x },
-      { translateY: ballAnimation.value.y },
+      { translateX: withTiming(ballAnimation.value.x, { duration: UPDATE_INTERVAL, easing: Easing.linear }) },
+      { translateY: withTiming(ballAnimation.value.y, { duration: UPDATE_INTERVAL, easing: Easing.linear }) },
     ],
   }));
 
@@ -64,15 +67,14 @@ const Game = () => {
   // Create the target styles based on the current ballAnimation value
   const targetPosition = useAnimatedStyle(() => ({
     transform: [
-      { translateX: targetAnimation.value.x },
-      { translateY: targetAnimation.value.y },
+      { translateX: withTiming(targetAnimation.value.x, { duration: 350 }) },
+      { translateY: withTiming(targetAnimation.value.y, { duration: 350 }) },
     ],
   }));
 
   // Setup the device motion sensor listner
   React.useEffect(() => {
-    // Set the update interval to 16ms (60fps)
-    DeviceMotion.setUpdateInterval(16);
+    DeviceMotion.setUpdateInterval(UPDATE_INTERVAL);
 
     const subscription = DeviceMotion.addListener((deviceMotionMeasurment) => {
       // Don't do anthing if the expected `rotation` data is missing


### PR DESCRIPTION
The animations were a bit choppy on my iOS device, this adds one of Reanimated's `with*` transition functions for easing and smoothing.

Draft because applying it may be tricky; this only applies the change to `step5`. @robwalkerco let's discuss if/how we should weave this into the steps and diffs (maybe PR it into the steps, rebase it into the diffs?)

Before (main issue is the red ball movement): 

https://github.com/nearform/react-native-workshop/assets/29628323/b216c069-4b7f-4db3-9870-4e85afecb84e

After (main improvement is smoother red ball, blue circle animation is bonus): 

https://github.com/nearform/react-native-workshop/assets/29628323/34c022d8-e084-41df-ace8-9199b800fc00

