### PR TITLE
Add top level git-ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,35 @@
+# Learn more https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files
+
+# dependencies
+node_modules/
+
+# Expo
+.expo/
+dist/
+web-build/
+
+# Native
+*.orig.*
+*.jks
+*.p8
+*.p12
+*.key
+*.mobileprovision
+
+# Metro
+.metro-health-check*
+
+# debug
+npm-debug.*
+yarn-debug.*
+yarn-error.*
+
+# macOS
 .DS_Store
+*.pem
+
+# local env files
+.env*.local
+
+# typescript
+*.tsbuildinfo


### PR DESCRIPTION
We've got gitignores in each individual directory already, but not having a top-level one causes problems if someone switches between branches that contain different directories

e.g. if they go into the "extra content" branch and develop that app, then switch back to main, that directory's gitignore goes, dumping all of the previously-gitignored node_modules etc into git 