### PR TITLE
Remove references to "NodeConf"

### DIFF
--- a/slides/slides.md
+++ b/slides/slides.md
@@ -205,9 +205,9 @@ https://expo.dev/client
 # [Step 0: Hello world](https://github.com/nearform/react-native-workshop/tree/main/step0)
 
 - Create and run starter Expo app:
-  - `npx create-expo-app NodeConfGame --template`
+  - `npx create-expo-app WorkshopGame --template`
   - Pick <b>"Blank"</b> for JavaScript, or "Blank (TypeScript)"
-  - `cd NodeConfGame` then  `npm i`
+  - `cd WorkshopGame` then  `npm i`
   - `npm start -- --tunnel`
   - Follow the instructions in terminal
 

--- a/slides/slides.md
+++ b/slides/slides.md
@@ -29,12 +29,11 @@ https://expo.dev/client
 
 # React Native Workshop: Setup
 
-Save time later, start things downloading now!
+On your <b>dev computer</b> 👇
 
-On your <b>laptop</b> 👇
-
-- `npm install --global @expo/ngrok`
-- On Mac or Linux, install Watchman:
+- On public WiFi? (hotel, cafe, train...)
+   - `npm install --global @expo/ngrok`
+- On Mac or Linux? Install Watchman
    - https://facebook.github.io/watchman/docs/install
 
 On your <b>Android or iOS device</b> 👉 👉 👉 👉 👉 👉 👉 👉 👉 👉 👉 👉 👉 👉

--- a/step0/README.md
+++ b/step0/README.md
@@ -17,14 +17,14 @@ This creates an Expo app, and lets you choose which of Expo's built-in app templ
 - For this workshop, we recommend the default, **"Blank"**, which is a minimal working app in JavaScript
 - If you're comfortable with TypeScript, feel free to use **"Blank (TypeScript)"** 
 
-If you want to continue exploring React Native after this workshop, consider creating another app with their "Navigation" template. It's a good starting point for playing with a simple information-heavy app.
+If you want to continue exploring React Native after this workshop, consider creating another app with their "Navigation" template. It's a good starting point for more textual apps.
 
 > [!NOTE]
 > #### JavaScript or TypeScript?
 > 
 > This workshop content focuses on JavaScript, to be accessible to more people.
 >
-> For real React Native apps going into production, however, we recommend using TypeScript. Bugs in production are harder to fix in mobile apps than on web or a server as the app store release process is much slower. Also, a lot of next-generation advanced React Native features are increasingly using strict TypeScript for better integrations with strongly-typed native code.
+> For real React Native apps going into production, however, we recommend using TypeScript. Bugs in production are harder to fix in mobile apps than on web or a server as the app store release process is much slower. Also, many React Native "new architecture" features use strict TypeScript for better integrations with strongly-typed native code.
 > 
 > If you decide to invest serious time in React Native, consider also investing time in TypeScript.
 
@@ -40,21 +40,29 @@ npm install
 
 ### 3. Start Expo
 
+Start the Expo Metro server on your local network:
+
 ```sh
-npm start -- --tunnel
+npm start
 ```
 
-This may prompt you to install `ngrok`, a service which helps serve your local app code to Expo's services.
-
-> [!NOTE]
-> The default way to start an Expo app is `npm run start`, which runs `expo start` starting the Expo "Metro" server on a 192.168... network address. This works great on private WiFi, but does not work on public WiFi like this hotel's. Using the `--tunnel` flag starts a web server that sends the data over public internet. This relies on [ngrok](https://ngrok.com/) and can be a little slower to run.
-> 
-> Tunnel connections are usually robust, but can snarl up: if this happens, try restarting the service and clearing the cache by adding `-c` - like `npm start -- --tunnel -c`.
-
 > [!IMPORTANT]
-> **If you can't get this to work**, try to create a WLAN connection via a hotspot, instead of a tunnel via the public internet:
-> - We've got a Raspberry Pi hotspot running in this room! Network name `nodepi` password `kilkenny`. Connect to that on **both** laptop and android/ios device and run `npm start`.
-> - If that doesn't work but you have a good data connection on your phone (and low/no data roaming fees!), try setting up a WiFi hotspot on your device, connect your laptop to that, then run `npm start`. 
+>
+> **Public wifi networks** like hotels, cafes, or some locked-down office networks may not allow this.
+> Try Expo's "tunnel" option, which uses an internet address instead of LAN:
+>
+> ```sh
+> npm start -- --tunnel
+> ```
+>
+> It's a little slower than the default LAN option, and may prompt you to install `ngrok` to
+> serve data from your computer to Expo's servers.
+>
+> **If this doesn't work either**, but you have a good mobile data connection (and low mobile data 
+> fees!), you could try setting up a WiFi hotspot on your device, connect your laptop to that,
+> then run `npm start`, using your hotspot as a LAN.
+>
+> If nothing works, or you have intermittent network problems, see "Troubleshooting" section below.
 
 ### 4. View the app in Expo Go
 
@@ -79,11 +87,11 @@ Open `App.js`, make some small change like editing this text, save, and it shoul
 
  - If something doesn't look right, first try pressing `r` in the Expo Metro server terminal to reload the app. A lot of problems disappear with a reload
  - If you already had Expo Go installed before this workshop and you encounter problems, check it is up to date
- - If the app gets stuck on a loading screen, try restarting Expo app, or restarting the Expo terminal with or without the `--tunnel` flag
+ - If the app gets stuck on a loading screen, try restarting Expo app, or restarting the Expo terminal with or without the `--tunnel` flag. Try also adding the `-c` flag to clear caches
  - If the Expo app fails with "Something went wrong", check the terminal is still running (and try restarting it), and check the devices are on the same network
  
- If you have persistent network trouble:
+If you have persistent network trouble:
  
-  - Check you don't have a firewall or similar blocking your laptop from running a local network server or your device from connecting to it.
-  - Create a (free) Expo account and log in on both devices. This should enable Expo Go to get your app data from Expo's servers via normal `https`.
-  - Try using a USB cable. For Android, you may also need to install `adb` and enable USB Debugging on the Android device.
+ - Check you don't have a firewall or similar blocking your laptop from running a local network server or your device from connecting to it.
+ - Create a [(free) Expo account](https://expo.dev) and log in on both devices. This should enable Expo Go to get your app data from Expo's servers via normal `https`.
+ - Try using a USB cable. For Android, you may also need to install `adb` and enable USB Debugging on the Android device.

--- a/step0/README.md
+++ b/step0/README.md
@@ -9,7 +9,7 @@ Objectives:
 ### 1. Create Expo project
 
 ```sh
-npx create-expo-app NodeConfGame --template
+npx create-expo-app WorkshopGame --template
 ```
 
 This creates an Expo app, and lets you choose which of Expo's built-in app templates to use:
@@ -31,7 +31,7 @@ If you want to continue exploring React Native after this workshop, consider cre
 ### 2. Install dependencies
 
 ```sh
-cd NodeConfGame
+cd WorkshopGame
 ```
 
 ```sh

--- a/step0/app.json
+++ b/step0/app.json
@@ -1,7 +1,7 @@
 {
   "expo": {
-    "name": "NodeConfGame",
-    "slug": "NodeConfGame",
+    "name": "WorkshopGame",
+    "slug": "WorkshopGame",
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",

--- a/step0/package-lock.json
+++ b/step0/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "nodeconfgame",
+  "name": "workshopgame",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "nodeconfgame",
+      "name": "workshopgame",
       "version": "1.0.0",
       "dependencies": {
         "expo": "~49.0.15",

--- a/step0/package.json
+++ b/step0/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "nodeconfgame",
+  "name": "workshopgame",
   "version": "1.0.0",
   "main": "node_modules/expo/AppEntry.js",
   "scripts": {

--- a/step1/app.json
+++ b/step1/app.json
@@ -1,7 +1,7 @@
 {
   "expo": {
-    "name": "NodeConfGame",
-    "slug": "NodeConfGame",
+    "name": "WorkshopGame",
+    "slug": "WorkshopGame",
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",

--- a/step1/package-lock.json
+++ b/step1/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "nodeconfgame",
+  "name": "workshopgame",
   "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "nodeconfgame",
+      "name": "workshopgame",
       "version": "1.0.0",
       "dependencies": {
         "@types/react": "~18.2.14",

--- a/step1/package.json
+++ b/step1/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "nodeconfgame",
+  "name": "workshopgame",
   "version": "1.0.0",
   "main": "node_modules/expo/AppEntry.js",
   "scripts": {

--- a/step2/app.json
+++ b/step2/app.json
@@ -1,7 +1,7 @@
 {
   "expo": {
-    "name": "NodeConfGame",
-    "slug": "NodeConfGame",
+    "name": "WorkshopGame",
+    "slug": "WorkshopGame",
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",

--- a/step2/package-lock.json
+++ b/step2/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "nodeconfgame",
+  "name": "workshopgame",
   "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "nodeconfgame",
+      "name": "workshopgame",
       "version": "1.0.0",
       "dependencies": {
         "@types/react": "~18.2.14",

--- a/step2/package.json
+++ b/step2/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "nodeconfgame",
+  "name": "workshopgame",
   "version": "1.0.0",
   "main": "node_modules/expo/AppEntry.js",
   "scripts": {

--- a/step3/app.json
+++ b/step3/app.json
@@ -1,7 +1,7 @@
 {
   "expo": {
-    "name": "NodeConfGame",
-    "slug": "NodeConfGame",
+    "name": "WorkshopGame",
+    "slug": "WorkshopGame",
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",

--- a/step3/package-lock.json
+++ b/step3/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "nodeconfgame",
+  "name": "workshopgame",
   "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "nodeconfgame",
+      "name": "workshopgame",
       "version": "1.0.0",
       "dependencies": {
         "@types/react": "~18.2.14",

--- a/step3/package.json
+++ b/step3/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "nodeconfgame",
+  "name": "workshopgame",
   "version": "1.0.0",
   "main": "node_modules/expo/AppEntry.js",
   "scripts": {

--- a/step4/app.json
+++ b/step4/app.json
@@ -1,7 +1,7 @@
 {
   "expo": {
-    "name": "NodeConfGame",
-    "slug": "NodeConfGame",
+    "name": "WorkshopGame",
+    "slug": "WorkshopGame",
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",

--- a/step4/package-lock.json
+++ b/step4/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "nodeconfgame",
+  "name": "workshopgame",
   "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "nodeconfgame",
+      "name": "workshopgame",
       "version": "1.0.0",
       "dependencies": {
         "@types/react": "~18.2.14",

--- a/step4/package.json
+++ b/step4/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "nodeconfgame",
+  "name": "workshopgame",
   "version": "1.0.0",
   "main": "node_modules/expo/AppEntry.js",
   "scripts": {

--- a/step5/app.json
+++ b/step5/app.json
@@ -1,7 +1,7 @@
 {
   "expo": {
-    "name": "NodeConfGame",
-    "slug": "NodeConfGame",
+    "name": "WorkshopGame",
+    "slug": "WorkshopGame",
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",

--- a/step5/package-lock.json
+++ b/step5/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "nodeconfgame",
+  "name": "workshopgame",
   "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "nodeconfgame",
+      "name": "workshopgame",
       "version": "1.0.0",
       "dependencies": {
         "@types/react": "~18.2.14",

--- a/step5/package.json
+++ b/step5/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "nodeconfgame",
+  "name": "workshopgame",
   "version": "1.0.0",
   "main": "node_modules/expo/AppEntry.js",
   "scripts": {


### PR DESCRIPTION
Closes https://github.com/nearform/react-native-workshop/issues/38

This workshop was originally developed for NodeConf EU 2023, but is now being used beyond that, so this PR removes the last few references to NodeConf [edit] and content that presumes the user is in a hotel (and, the password for Cody's improvised Raspberry Pi WLAN!).

It'll need to be rebased into each of the "step" branches.